### PR TITLE
Allow vocab definitions to be longer than two words

### DIFF
--- a/expose.notes
+++ b/expose.notes
@@ -35,6 +35,7 @@ Another header:
 
 vocab: and its definition
 two word: and its definition
+longer vocab word-sequence: and its definition
 
 # Highlights
 ## Another highlight

--- a/notes.YAML-tmLanguage
+++ b/notes.YAML-tmLanguage
@@ -527,5 +527,5 @@ patterns:
   match: ([\(\)])
 - comment: Top-level vocab definitions
   name: keyword.other.notes
-  match: ^((\w+\s?\w*\:)(?=[ \t][\w\d]))
+  match: ^(([\w\+-=\/?!@#$%^&()~]+(\s?[\w\+-=\/?!@#$%^&()~]*)*\:)(?=[ \t][\w\d]))
 ...

--- a/notes.tmLanguage
+++ b/notes.tmLanguage
@@ -1994,7 +1994,7 @@
 			<key>comment</key>
 			<string>Top-level vocab definitions</string>
 			<key>match</key>
-			<string>^((\w+\s?\w*\:)(?=[ \t][\w\d]))</string>
+			<string>^(([\w\+-=\/?!@#$%^&amp;()~]+(\s?[\w\+-=\/?!@#$%^&amp;()~]*)*\:)(?=[ \t][\w\d]))</string>
 			<key>name</key>
 			<string>keyword.other.notes</string>
 		</dict>

--- a/tnotes.tmLanguage
+++ b/tnotes.tmLanguage
@@ -1994,7 +1994,7 @@
 			<key>comment</key>
 			<string>Top-level vocab definitions</string>
 			<key>match</key>
-			<string>^((\w+\s?\w*\:)(?=[ \t][\w\d]))</string>
+			<string>^(([\w\+-=\/?!@#$%^&amp;()~]+(\s?[\w\+-=\/?!@#$%^&amp;()~]*)*\:)(?=[ \t][\w\d]))</string>
 			<key>name</key>
 			<string>keyword.other.notes</string>
 		</dict>


### PR DESCRIPTION
I wanted vocab definitions to support being longer than two words, and for it to support "special" characters like dashes and dollar signs, etc. Useful for taking notes in class when vocab words can be many words put together.
