### PR TITLE
Add support of Headers for all languages

### DIFF
--- a/notes.YAML-tmLanguage
+++ b/notes.YAML-tmLanguage
@@ -513,7 +513,7 @@ patterns:
     '1': {name: variable.language.notes}
 - comment: Headers
   name: entity.name.tag.notes
-  match: ^([A-Z].*\:)$
+  match: ^(\p{Lu}.*\:)$
 - comment: Proper headers
   name: entity.name.tag.notes
   match: ^([-=]+\s?\w[\w\s]*[\-=]+)

--- a/notes.tmLanguage
+++ b/notes.tmLanguage
@@ -1938,7 +1938,7 @@
 			<key>comment</key>
 			<string>Headers</string>
 			<key>match</key>
-			<string>^([A-Z].*\:)$</string>
+			<string>^(\p{Lu}.*\:)$</string>
 			<key>name</key>
 			<string>entity.name.tag.notes</string>
 		</dict>
@@ -1997,3 +1997,4 @@
 	<string>b9bf3970-f517-46fd-a7f8-ae78fd761f84</string>
 </dict>
 </plist>
+

--- a/notes.tmLanguage
+++ b/notes.tmLanguage
@@ -1997,4 +1997,3 @@
 	<string>b9bf3970-f517-46fd-a7f8-ae78fd761f84</string>
 </dict>
 </plist>
-

--- a/tnotes.tmLanguage
+++ b/tnotes.tmLanguage
@@ -1938,7 +1938,7 @@
 			<key>comment</key>
 			<string>Headers</string>
 			<key>match</key>
-			<string>^([A-Z].*\:)$</string>
+			<string>^(\p{Lu}.*\:)$</string>
 			<key>name</key>
 			<string>entity.name.tag.notes</string>
 		</dict>


### PR DESCRIPTION
Replaced regular expression `\p{Lu}` instead `[A-Z]` for supporting Cyrillic letters.

You can check this:
https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#SupportedUnicodeGeneralCategories