### PR TITLE
Support inline !=

### DIFF
--- a/notes.YAML-tmLanguage
+++ b/notes.YAML-tmLanguage
@@ -525,7 +525,7 @@ patterns:
   match: (\"[^\"]*\")
 - comment: Warning/critical
   name: invalid.deprecated.notes
-  match: (?![a-zA-Z])\!+[^\!\n\r]+\!*
+  match: (?![a-zA-Z])\!+[^\!\n\r=]+\!*
 - comment: Emphasis on parentheses
   name: keyword.operator
   match: ([\(\)])

--- a/notes.tmLanguage
+++ b/notes.tmLanguage
@@ -1970,7 +1970,7 @@
 			<key>comment</key>
 			<string>Warning/critical</string>
 			<key>match</key>
-			<string>(?![a-zA-Z])\!+[^\!\n\r]+\!*</string>
+			<string>(?![a-zA-Z])\!+[^\!\n\r=]+\!*</string>
 			<key>name</key>
 			<string>invalid.deprecated.notes</string>
 		</dict>

--- a/tnotes.tmLanguage
+++ b/tnotes.tmLanguage
@@ -1970,7 +1970,7 @@
 			<key>comment</key>
 			<string>Warning/critical</string>
 			<key>match</key>
-			<string>(?![a-zA-Z])\!+[^\!\n\r]+\!*</string>
+			<string>(?![a-zA-Z])\!+[^\!\n\r=]+\!*</string>
 			<key>name</key>
 			<string>invalid.deprecated.notes</string>
 		</dict>


### PR DESCRIPTION
Previously everything after ! was bolded in a critical section. Now !=
does not start a critical section.