### PR TITLE
Fix [js] in readme.notes

### DIFF
--- a/messages/readme.notes
+++ b/messages/readme.notes
@@ -63,7 +63,7 @@ Code Snippets:
 
 [js]
 	(function (a, b) {
-		return {of.all = {major: 'languages'}
+		return {of.all = {major: 'languages'}};
 	})(alpha, beta);
 [end]
 


### PR DESCRIPTION
The end of the function is never reached so the rest of readme.notes is considered as js.