### PR TITLE
Improve warning/critical match expression and update ReadMe

### DIFF
--- a/notes.YAML-tmLanguage
+++ b/notes.YAML-tmLanguage
@@ -525,7 +525,7 @@ patterns:
   match: (\"[^\"]*\")
 - comment: Warning/critical
   name: invalid.deprecated.notes
-  match: (?![a-zA-Z])\!+[^\!\n\r]+\!*
+  match: (!!([^!]+)!!)
 - comment: Emphasis on parentheses
   name: keyword.operator
   match: ([\(\)])

--- a/notes.tmLanguage
+++ b/notes.tmLanguage
@@ -1970,7 +1970,7 @@
 			<key>comment</key>
 			<string>Warning/critical</string>
 			<key>match</key>
-			<string>(?![a-zA-Z])\!+[^\!\n\r]+\!*</string>
+			<string>(!!([^!]+)!!)</string>
 			<key>name</key>
 			<string>invalid.deprecated.notes</string>
 		</dict>

--- a/readme.md
+++ b/readme.md
@@ -1,31 +1,31 @@
-#Notes for Sublime Text
+# Notes for Sublime Text
 
-##A _Very_ Simple Language for Taking Notes
+## A _Very_ Simple Language for Taking Notes
 
 If you're like me, you find yourself taking a lot of notes in Sublime. I like syntax highlighting, and I thought it would be cool to see it applied to every day note taking.
 Now you can enjoy your beautiful color schemes while taking everyday notes!
 
 ![alt tag](docs/img/notes-signalr-example.png?raw=true)
 
-##Installation
+## Installation
 Install via Sublime's [Package Manager](https://sublime.wbond.net/installation).
 - Open the command palette: `⌘+shift+p` on MacOS/Linux, `ctrl+shift+p` on Windows
 - type `install`, select `Package Control: Install Package`
 - type `Notes`, select `Notes`
 
-##Usage
+## Usage
 - Open the command palette: `⌘+shift+p` on MacOS/Linux, `ctrl+shift+p` on Windows
 - type `notes`
 - or save as a .notes file
 
-##Features
+## Features
 ![alt tag](docs/img/notes-quicklook.png?raw=true)
 
-##Snippets
+## Snippets
 - generate block title: `--- + TAB`
 - generate code snippet: `[ + TAB`
 
-##Supported languages for snippets
+## Supported languages for snippets
 - Actionscript
 - Applescript
 - ASP


### PR DESCRIPTION
This fork has two purposes:

1. Improve the match expression for the "super important" emphasis.
2. Update the README so that the headers are rendered in Github.

# For Purpose 1:
In the original documentation, there is an example of this where text between two exclamation points is highlighted, such as: 

!! HIGHLIGHTED TEXT !!

I found that in practice, this does not accurately reflect the regex used to detect the super important emphasis. 
The original REGEX highlights every character on a line found after a single exclamation point, which makes organic note-taking look strange with the highlighting occurring seemingly at random places.

I much preferred how the example screenshot demonstrates this feature, so I tuned the regex to behave as such. 
Now, it will highlight any and all text (across multiple lines) ONLY between unique sets of _two_ exclamation points.

# For Purpose 2:
The current README has markdown headers, but they aren't properly formatted. 
As of now, the #'s are not separated from the text with a space, causing the headers to be rendered as plaintext. By adding that space, the README becomes a bit more readable!